### PR TITLE
環境変数の設定＆いろいろ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -147,17 +147,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -206,12 +196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,19 +240,6 @@ dependencies = [
  "getrandom",
  "libredox",
  "thiserror",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -332,16 +303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
-dependencies = [
- "rustix",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,15 +348,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -404,81 +356,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
- "anstream",
- "anstyle",
- "is_terminal_polyfill",
  "memchr",
- "terminal_size",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,31 +49,33 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "asari"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.4"
 dependencies = [
  "anyhow",
  "clap",
  "dirs",
+ "serde",
+ "serde_json",
  "unicode-ident",
  "winnow",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cfg-if"
@@ -83,18 +85,19 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -103,10 +106,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_lex"
-version = "0.7.7"
+name = "clap_derive"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -132,7 +147,17 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -147,16 +172,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "libc"
-version = "0.2.181"
+name = "itoa"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libredox"
@@ -167,6 +204,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "memchr"
@@ -216,6 +259,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,13 +322,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -254,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -278,6 +387,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -286,10 +404,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
+ "anstream",
+ "anstyle",
+ "is_terminal_polyfill",
  "memchr",
+ "terminal_size",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "asari"
+default-run = "asari"
 version = "0.1.0-alpha.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ serde_json = "1"
 
 [dependencies.winnow]
 version = "0.7"
-features = ["debug"]
+#features = ["debug"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "asari"
 default-run = "asari"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-clap = "4"
+clap = { version = "4", features = ["derive"] }
 dirs = "6"
 unicode-ident = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dependencies.winnow]
 version = "0.7"
-#features = ["debug"]
+features = ["debug"]

--- a/src/bin/echo.rs
+++ b/src/bin/echo.rs
@@ -1,0 +1,11 @@
+use std::io::Write;
+
+fn main() {
+    if let Err(e) = writeln!(
+        std::io::stdout(),
+        "{}",
+        std::env::args().skip(1).collect::<Vec<_>>().join(" ")
+    ) {
+        eprintln!("{e}");
+    }
+}

--- a/src/bin/echo.rs
+++ b/src/bin/echo.rs
@@ -1,11 +1,14 @@
-use std::io::Write;
+use std::{
+    env::args,
+    io::{Write, stdout},
+};
 
 fn main() {
-    if let Err(e) = writeln!(
-        std::io::stdout(),
-        "{}",
-        std::env::args().skip(1).collect::<Vec<_>>().join(" ")
-    ) {
+    let result =
+        writeln!(stdout(), "{}", args().skip(1).collect::<Vec<_>>().join(" "));
+    if let Err(e) = result
+        && e.kind() != std::io::ErrorKind::BrokenPipe
+    {
         eprintln!("{e}");
     }
 }

--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+
+fn main() {
+    let current_dir = std::env::current_dir()
+        .expect("現在のディレクトリの取得に失敗しました");
+
+    let dir = if let Some(path) = std::env::args().nth(1) {
+        let path = PathBuf::from(path);
+        if path.is_relative() {
+            current_dir.join(path)
+        }
+        else {
+            path
+        }
+    }
+    else {
+        current_dir
+    };
+
+    let mut files = dir
+        .read_dir()
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter(|file_name| !file_name.starts_with('.'))
+        .collect::<Vec<_>>();
+    files.sort();
+    println!("{}", files.join("\n"));
+}

--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, process::exit};
 
 fn main() {
     let current_dir = std::env::current_dir()
@@ -17,9 +17,14 @@ fn main() {
         current_dir
     };
 
-    let mut files = dir
-        .read_dir()
-        .unwrap()
+    let read_dir = match dir.read_dir() {
+        Ok(read_dir) => read_dir,
+        Err(e) => {
+            eprintln!("{e}");
+            exit(1)
+        }
+    };
+    let mut files = read_dir
         .filter_map(|entry| entry.ok())
         .filter_map(|entry| entry.file_name().into_string().ok())
         .filter(|file_name| !file_name.starts_with('.'))

--- a/src/bin/mkdir.rs
+++ b/src/bin/mkdir.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let mut exit_status = 0;
+    for dir in std::env::args().skip(1) {
+        match std::fs::create_dir_all(dir) {
+            Ok(_) => {}
+            Err(e) => {
+                exit_status = 1;
+                eprintln!("{e}");
+            }
+        }
+    }
+    std::process::exit(exit_status);
+}

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -24,18 +24,14 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 
 #[derive(Clone, Copy, Debug)]
 pub enum BuiltinCommand {
-    Echo,
     Cd,
     Exit,
-    Mkdir,
 }
 pub fn find_command(name: &str) -> Option<BuiltinCommand> {
     use BuiltinCommand::*;
     Some(match name {
-        "echo" => Echo,
         "cd" => Cd,
         "exit" => Exit,
-        "mkdir" => Mkdir,
         _ => None?,
     })
 }
@@ -48,10 +44,8 @@ pub fn run(
 ) -> Result<i32> {
     use BuiltinCommand::*;
     let result = match command {
-        Echo => echo(args, stdin, stdout, stderr),
         Cd => cd(args, stdin, stdout, stderr),
         Exit => exit(args, stdin, stdout, stderr),
-        Mkdir => mkdir(args, stdin, stdout, stderr),
     };
     if let Err(Error::Stdio(e)) = &result
         && e.kind() == std::io::ErrorKind::BrokenPipe
@@ -59,18 +53,6 @@ pub fn run(
         return Ok(0);
     }
     result
-}
-fn echo(
-    args: &[Value],
-    _stdin: Box<dyn Read>,
-    mut stdout: Box<dyn Write>,
-    _stderr: Box<dyn Write>,
-) -> Result<i32> {
-    let args = args.iter().flat_map(Value::to_args).collect::<Vec<_>>();
-    if !args.is_empty() {
-        writeln!(stdout, "{}", args.join(" ")).map_err(Error::Stdio)?;
-    }
-    Ok(0)
 }
 fn cd(
     args: &[Value],
@@ -155,26 +137,4 @@ fn exit(
         }
     }
     Err(Error::Exit(exit_code))
-}
-fn mkdir(
-    args: &[Value],
-    _stdin: Box<dyn Read>,
-    _stdout: Box<dyn Write>,
-    mut stderr: Box<dyn Write>,
-) -> Result<i32> {
-    if args.is_empty() {
-        return Err(Error::InvalidArgs);
-    }
-
-    let mut exit_status = 0;
-    for dir in args.iter().flat_map(Value::to_args) {
-        match std::fs::create_dir_all(dir) {
-            Ok(_) => {}
-            Err(e) => {
-                exit_status = 1;
-                writeln!(stderr, "{e}")?;
-            }
-        }
-    }
-    Ok(exit_status)
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,6 +1,6 @@
 use crate::parse::{
-    Command, MergeRedirect, OutputRedirect, Pipe, Pipeline, Redirect,
-    ShellCommand, Spanned,
+    Command, EnvAssign, MergeRedirect, OutputRedirect, Pipe, Pipeline,
+    Redirect, ShellCommand, Spanned, Statement,
 };
 
 #[derive(Clone, Debug)]
@@ -18,9 +18,25 @@ pub fn check_shell_command(
     shell_command: &Spanned<ShellCommand>,
     errors: &mut Vec<CheckError>,
 ) {
-    for pipeline in &shell_command.inner.pipelines {
-        check_pipline(pipeline, errors);
+    for statement in &shell_command.inner.statements {
+        check_statement(statement, errors);
     }
+}
+fn check_statement(
+    statement: &Spanned<Statement>,
+    errors: &mut Vec<CheckError>,
+) {
+    use Statement::*;
+    match &statement.inner {
+        Pipeline(pipeline) => check_pipline(pipeline, errors),
+        EnvAssign(env_assign) => check_env_assign(env_assign, errors),
+    }
+}
+fn check_env_assign(
+    _env_assign: &Spanned<EnvAssign>,
+    _errors: &mut Vec<CheckError>,
+) {
+    // 型チェックでもする
 }
 fn check_pipline(pipeline: &Spanned<Pipeline>, errors: &mut Vec<CheckError>) {
     let pipeline = &pipeline.inner;

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,6 +1,6 @@
 use crate::parse::{
-    Command, EnvAssign, MergeRedirect, OutputRedirect, Pipe, Pipeline,
-    Redirect, ShellCommand, Spanned, Statement,
+    Command, CommandLine, EnvAssign, MergeRedirect, OutputRedirect, Pipe,
+    Pipeline, Redirect, ShellCommand, Spanned, Statement,
 };
 
 #[derive(Clone, Debug)]
@@ -14,11 +14,11 @@ pub enum RedirectError {
     DuplicateStderr,
 }
 
-pub fn check_shell_command(
-    shell_command: &Spanned<ShellCommand>,
+pub fn check_command_line(
+    command_line: &Spanned<CommandLine>,
     errors: &mut Vec<CheckError>,
 ) {
-    for statement in &shell_command.inner.statements {
+    for statement in &command_line.inner.statements {
         check_statement(statement, errors);
     }
 }
@@ -28,9 +28,18 @@ fn check_statement(
 ) {
     use Statement::*;
     match &statement.inner {
+        ShellCommand(shell_command) => {
+            check_shell_command(shell_command, errors)
+        }
         Pipeline(pipeline) => check_pipline(pipeline, errors),
         EnvAssign(env_assign) => check_env_assign(env_assign, errors),
     }
+}
+fn check_shell_command(
+    _shell_command: &Spanned<ShellCommand>,
+    _errors: &mut Vec<CheckError>,
+) {
+    // 型チェックでもする
 }
 fn check_env_assign(
     _env_assign: &Spanned<EnvAssign>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "asari", version)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    Subst { payload_path: PathBuf },
+}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,20 +1,20 @@
+use crate::exec::Error as ExecError;
+use crate::parse::{
+    CommandPart, Expr, ExprInfix, ExprPostfix, ExprPrefix, Primary, Spanned,
+    SpecialVar,
+};
+use crate::value::*;
+
 use std::{
     collections::HashMap,
     path::{Component, Path, PathBuf},
     string::String,
 };
 
-use crate::{
-    exec::{Error as ExecError, Output, execute_shell_command},
-    parse::{
-        CommandPart, Expr, ExprInfix, ExprPostfix, ExprPrefix, Primary,
-        Spanned, SpecialVar,
-    },
-    value::*,
-};
+use serde::{Deserialize, Serialize};
 
 type Result<T> = ::std::result::Result<T, ExecError>;
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Error {
     InvalidType,
     OverFlow,
@@ -24,12 +24,15 @@ pub enum Error {
     NoHomeDir,
     InvalidUtf8Path,
     InvalidGlobPattern,
+    SubstError(std::io::Error),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Context {
     pub shell_name: String,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub shell_vars: HashMap<String, Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_pid: Option<u32>,
     pub last_status: i32,
 }
@@ -269,26 +272,33 @@ fn eval_primary(
             .into(),
         Unit => ().into(),
         CommandSubst(shell_command) => {
-            let mut child_env = env.clone();
-            let mut output = Output::Capture(Vec::new());
-            match execute_shell_command(
-                shell_command,
-                &mut output,
-                &mut child_env,
-            ) {
-                Ok(()) => {}
-                Err(ExecError::Exit(code)) => {
-                    env.last_status = code;
-                    return Ok("".to_string().into());
-                }
-                Err(e) => return Err(e),
-            }
-            env.last_status = child_env.last_status;
-            let Output::Capture(output) = output
-            else {
-                unreachable!()
-            };
-            std::string::String::from_utf8(output)
+            use std::process::Stdio;
+
+            // 実行すべきコマンドとシェル変数などを含んだ環境を一時ファイルへ保存
+            let path =
+                crate::payload::write_payload(&crate::payload::SubstPayload {
+                    command: shell_command.as_ref().clone(),
+                    context: env.clone(),
+                })
+                .map_err(Error::SubstError)?;
+
+            // 自分自身をsubstモードで起動
+            let output = std::process::Command::new(
+                std::env::current_exe().map_err(Error::SubstError)?,
+            )
+            .arg("subst")
+            .arg(&path)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .output()
+            .map_err(Error::SubstError)?;
+
+            // 一時ファイルを削除
+            let _ = std::fs::remove_file(&path);
+
+            env.last_status = crate::exec::status_into_i32(output.status);
+            std::string::String::from_utf8(output.stdout)
                 .map_err(|_| ExecError::CommandOutIsNotUtf8)?
                 .trim_end_matches(['\r', '\n'])
                 .to_string()

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -294,9 +294,6 @@ fn eval_primary(
             .output()
             .map_err(Error::SubstError)?;
 
-            // 一時ファイルを削除
-            let _ = std::fs::remove_file(&path);
-
             env.last_status = crate::exec::status_into_i32(output.status);
             std::string::String::from_utf8(output.stdout)
                 .map_err(|_| ExecError::CommandOutIsNotUtf8)?

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -92,7 +92,7 @@ fn execute_statement(
                 .iter()
                 .map(|arg| eval_command_part(arg, env))
                 .collect::<Result<Vec<_>>>()?;
-            crate::shell_command::run(command, &args)?;
+            env.last_status = crate::shell_command::run(command, &args)?;
         }
         Pipeline(pipeline) => {
             // Exitエラーは伝播させる
@@ -557,6 +557,10 @@ fn get_path() -> Vec<PathBuf> {
             static BUILTIN_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
                 std::env::current_exe()
                     .expect("自身のファイルパスの取得に失敗しました")
+                    .parent()
+                    .expect("親ディレクトリの取得に失敗しました")
+                    .join("builtin")
+                    .to_path_buf()
             });
             // 最初にビルトインコマンドを探す
             [BUILTIN_DIR.clone()]

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -2,7 +2,7 @@ use crate::builtin::{Error as BuiltinError, find_command};
 use crate::eval::{Context, Error as EvalError, eval_command_part};
 use crate::parse::{
     Command, CommandPart, InputRedirect, MergeRedirect, OutputMode,
-    OutputRedirect, Pipe, Pipeline, Redirect, ShellCommand, Spanned,
+    OutputRedirect, Pipe, Pipeline, Redirect, ShellCommand, Spanned, Statement,
 };
 use crate::value::Value;
 
@@ -26,6 +26,7 @@ pub enum Error {
     InvalidRedirectFileType,
     FailOpenRedirectFile(IoError),
     CommandOutIsNotUtf8,
+    EnvAssignNotString,
 }
 impl From<EvalError> for Error {
     #[inline(always)]
@@ -95,12 +96,37 @@ pub fn execute_shell_command(
     output: &mut Output,
     env: &mut Context,
 ) -> Result<()> {
-    for pipeline in &shell_command.inner.pipelines {
-        if let Err(e) = execute_pipeline(pipeline, output, env) {
-            if matches!(e, Error::Exit(_)) {
-                return Err(e);
+    for statement in &shell_command.inner.statements {
+        execute_statement(statement, output, env)?;
+    }
+    Ok(())
+}
+pub fn execute_statement(
+    statement: &Spanned<Statement>,
+    output: &mut Output,
+    env: &mut Context,
+) -> Result<()> {
+    use Statement::*;
+    match &statement.inner {
+        Pipeline(pipeline) => {
+            // Exitエラーは伝播させる
+            // それ以外はエラー表示で次に進む
+            if let Err(e) = execute_pipeline(pipeline, output, env) {
+                if matches!(e, Error::Exit(_)) {
+                    return Err(e);
+                }
+                eprintln!("{e:?}");
             }
-            eprintln!("{e:?}");
+        }
+        EnvAssign(env_assign) => {
+            let name = &env_assign.inner.name.inner;
+            let value = eval_command_part(&env_assign.inner.value, env)?;
+            let Value::String(value) = value
+            else {
+                return Err(Error::EnvAssignNotString);
+            };
+            // シングルスレッドでのみ環境変数を書き換えているので安全
+            unsafe { std::env::set_var(name, value) };
         }
     }
     Ok(())
@@ -148,6 +174,7 @@ pub fn execute_pipeline(
     for resolved_command in resolved_commands {
         let ResolvedCommand {
             command,
+            envs,
             args,
             stdin,
             stdout,
@@ -177,6 +204,7 @@ pub fn execute_pipeline(
                     args.iter().flat_map(Value::to_args).collect::<Vec<_>>();
 
                 let external_handle = std::process::Command::new(command)
+                    .envs(envs)
                     .args(args)
                     .stdin(stdin)
                     .stdout(stdout)
@@ -221,6 +249,7 @@ enum ExecutableCommand {
 #[derive(Debug)]
 struct ResolvedCommand {
     command: ExecutableCommand,
+    envs: Vec<(String, String)>,
     args: Vec<Value>,
     stdin: StdioInputConfig,
     stdout: StdioOutputConfig,
@@ -260,6 +289,7 @@ impl ResolvedCommand {
 
         Ok(Self {
             command,
+            envs: vec![],
             args,
             stdin: StdioInputConfig::default(),
             stdout: StdioOutputConfig::default(),

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,5 +1,5 @@
 use crate::builtin::{Error as BuiltinError, find_command};
-use crate::eval::{Context, Error as EvalError, eval_command_part};
+use crate::eval::{Context, Error as EvalError, eval_command_part, eval_expr};
 use crate::parse::{
     Command, CommandPart, InputRedirect, MergeRedirect, OutputMode,
     OutputRedirect, Pipe, Pipeline, Redirect, ShellCommand, Spanned, Statement,
@@ -26,7 +26,8 @@ pub enum Error {
     InvalidRedirectFileType,
     FailOpenRedirectFile(IoError),
     CommandOutIsNotUtf8,
-    EnvAssignNotString,
+    EnvAssignNotStringOrNone,
+    TempEnvAssignNotString,
 }
 impl From<EvalError> for Error {
     #[inline(always)]
@@ -120,13 +121,20 @@ pub fn execute_statement(
         }
         EnvAssign(env_assign) => {
             let name = &env_assign.inner.name.inner;
-            let value = eval_command_part(&env_assign.inner.value, env)?;
-            let Value::String(value) = value
-            else {
-                return Err(Error::EnvAssignNotString);
-            };
-            // シングルスレッドでのみ環境変数を書き換えているので安全
-            unsafe { std::env::set_var(name, value) };
+            let value = eval_expr(&env_assign.inner.value, env)?;
+            match value {
+                Value::String(value) => {
+                    // シングルスレッドでのみ環境変数を書き換えているので安全
+                    unsafe { std::env::set_var(name, value) };
+                }
+                Value::Option(None) => {
+                    // シングルスレッドでのみ環境変数を書き換えているので安全
+                    unsafe { std::env::remove_var(name) };
+                }
+                _ => {
+                    return Err(Error::EnvAssignNotStringOrNone);
+                }
+            }
         }
     }
     Ok(())
@@ -267,6 +275,21 @@ impl ResolvedCommand {
             return Err(Error::EmptyCommand);
         }
 
+        // 一時環境変数の評価
+        let envs: Vec<_> = command
+            .inner
+            .temp_env
+            .iter()
+            .map(|temp_env| {
+                let (env_var, env_val) = &temp_env.inner;
+                let Value::String(env_val) = eval_expr(env_val, env)?
+                else {
+                    return Err(Error::TempEnvAssignNotString);
+                };
+                Ok((env_var.inner.clone(), env_val))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
         // 引数の評価
         let args: Vec<_> = command
             .inner
@@ -289,7 +312,7 @@ impl ResolvedCommand {
 
         Ok(Self {
             command,
-            envs: vec![],
+            envs,
             args,
             stdin: StdioInputConfig::default(),
             stdout: StdioOutputConfig::default(),

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,12 +1,12 @@
-use crate::builtin::{Error as BuiltinError, find_command};
 use crate::eval::{Context, Error as EvalError, eval_command_part, eval_expr};
 use crate::parse::{
-    Command, CommandPart, InputRedirect, MergeRedirect, OutputMode,
-    OutputRedirect, Pipe, Pipeline, Redirect, ShellCommand, Spanned, Statement,
+    Command, CommandLine, CommandPart, InputRedirect, MergeRedirect,
+    OutputMode, OutputRedirect, Pipe, Pipeline, Redirect, Spanned, Statement,
 };
+use crate::shell_command::Error as BuiltinError;
 use crate::value::Value;
 
-use std::io::{Read, Write};
+use std::io::Write;
 use std::process::Stdio;
 use std::thread::JoinHandle;
 use std::{ffi::OsString, io::Error as IoError, path::PathBuf};
@@ -29,6 +29,7 @@ pub enum Error {
     EnvAssignNotStringOrNone,
     TempEnvAssignNotString,
 }
+impl std::error::Error for Error {}
 impl From<EvalError> for Error {
     #[inline(always)]
     fn from(value: EvalError) -> Self {
@@ -51,27 +52,6 @@ impl std::fmt::Display for Error {
 }
 type Result<T> = ::std::result::Result<T, Error>;
 
-pub enum Output {
-    Inherit,
-    Capture(Vec<u8>),
-}
-impl std::io::Write for Output {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        use Output::*;
-        match self {
-            Inherit => std::io::stdout().write(buf),
-            Capture(vec) => vec.write(buf),
-        }
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        use Output::*;
-        match self {
-            Inherit => std::io::stdout().flush(),
-            Capture(_) => Ok(()),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Default)]
 pub struct Shell {
     context: Context,
@@ -82,37 +62,42 @@ impl Shell {
     }
     pub fn execute(
         &mut self,
-        shell_command: &Spanned<ShellCommand>,
+        shell_command: &Spanned<CommandLine>,
     ) -> Result<()> {
-        execute_shell_command(
-            shell_command,
-            &mut Output::Inherit,
-            &mut self.context,
-        )
+        execute_command_line(shell_command, &mut self.context)
     }
 }
 
-pub fn execute_shell_command(
-    shell_command: &Spanned<ShellCommand>,
-    output: &mut Output,
+pub fn execute_command_line(
+    command_line: &Spanned<CommandLine>,
     env: &mut Context,
 ) -> Result<()> {
-    for statement in &shell_command.inner.statements {
-        execute_statement(statement, output, env)?;
+    for statement in &command_line.inner.statements {
+        execute_statement(statement, env)?;
     }
     Ok(())
 }
-pub fn execute_statement(
+
+fn execute_statement(
     statement: &Spanned<Statement>,
-    output: &mut Output,
     env: &mut Context,
 ) -> Result<()> {
     use Statement::*;
     match &statement.inner {
+        ShellCommand(shell_command) => {
+            let command = shell_command.inner.kind.inner;
+            let args = shell_command
+                .inner
+                .args
+                .iter()
+                .map(|arg| eval_command_part(arg, env))
+                .collect::<Result<Vec<_>>>()?;
+            crate::shell_command::run(command, &args)?;
+        }
         Pipeline(pipeline) => {
             // Exitエラーは伝播させる
             // それ以外はエラー表示で次に進む
-            if let Err(e) = execute_pipeline(pipeline, output, env) {
+            if let Err(e) = execute_pipeline(pipeline, env) {
                 if matches!(e, Error::Exit(_)) {
                     return Err(e);
                 }
@@ -124,6 +109,16 @@ pub fn execute_statement(
             let value = eval_expr(&env_assign.inner.value, env)?;
             match value {
                 Value::String(value) => {
+                    // シングルスレッドでのみ環境変数を書き換えているので安全
+                    unsafe { std::env::set_var(name, value) };
+                }
+                Value::Option(Some(value))
+                    if matches!(*value, Value::String(_)) =>
+                {
+                    let Value::String(value) = *value
+                    else {
+                        unreachable!()
+                    };
                     // シングルスレッドでのみ環境変数を書き換えているので安全
                     unsafe { std::env::set_var(name, value) };
                 }
@@ -140,48 +135,19 @@ pub fn execute_statement(
     Ok(())
 }
 
-enum CommandHandle {
-    External(std::process::Child),
-    Builtin(JoinHandle<crate::builtin::Result<i32>>),
-}
-impl CommandHandle {
-    fn wait(self) -> Result<i32> {
-        match self {
-            CommandHandle::External(mut child) => {
-                let status = child.wait().map_err(Error::CommandError)?;
-                Ok(status.code().unwrap_or(1))
-            }
-            CommandHandle::Builtin(handle) => {
-                // ビルトインコマンドのパニックは伝播させる
-                Ok(handle.join().unwrap()?)
-            }
-        }
-    }
-}
-
-pub fn execute_pipeline(
+fn execute_pipeline(
     pipeline: &Spanned<Pipeline>,
-    output: &mut Output,
     env: &mut Context,
 ) -> Result<()> {
-    // outputがCaptureならパイプを渡す
-    let (output_reader, output_writer) = match output {
-        Output::Inherit => (None, None),
-        Output::Capture(_) => {
-            let (reader, writer) = std::io::pipe().map_err(Error::PipeError)?;
-            (Some(reader), Some(writer))
-        }
-    };
-
     // コマンドの整理
-    let resolved_commands = resolve_pipeline(pipeline, output_writer, env)?;
+    let resolved_commands = resolve_pipeline(pipeline, env)?;
 
     // コマンドを実行
     let mut command_handles = vec![];
     let mut string_handles = vec![];
     for resolved_command in resolved_commands {
         let ResolvedCommand {
-            command,
+            name: command,
             envs,
             args,
             stdin,
@@ -189,74 +155,51 @@ pub fn execute_pipeline(
             stderr,
         } = resolved_command;
 
-        match command {
-            ExecutableCommand::Builtin(command) => {
-                let builtin_handle = std::thread::spawn(move || {
-                    let stdin = stdin.into_read();
-                    let stdout = stdout.into_write_stdout();
-                    let stderr = stderr.into_write_stderr();
-                    crate::builtin::run(command, &args, stdin, stdout, stderr)
-                });
-                command_handles.push(CommandHandle::Builtin(builtin_handle));
-            }
-            ExecutableCommand::External(command) => {
-                let (stdin, handle) = stdin.into_stdio()?;
-                let stdout = stdout.into_stdio();
-                let stderr = stderr.into_stdio();
-                if let Some(handle) = handle {
-                    string_handles.push(handle);
-                }
-
-                // 引数の展開
-                let args =
-                    args.iter().flat_map(Value::to_args).collect::<Vec<_>>();
-
-                let external_handle = std::process::Command::new(command)
-                    .envs(envs)
-                    .args(args)
-                    .stdin(stdin)
-                    .stdout(stdout)
-                    .stderr(stderr)
-                    .spawn()
-                    .map_err(Error::CommandError)?;
-                command_handles.push(CommandHandle::External(external_handle));
-            }
+        let (stdin, handle) = stdin.into_stdio()?;
+        let stdout = stdout.into_stdio();
+        let stderr = stderr.into_stdio();
+        if let Some(handle) = handle {
+            string_handles.push(handle);
         }
-    }
 
-    // アウトプットの受け取りスレッド
-    let output_handle = output_reader.map(|mut reader| {
-        std::thread::spawn(move || {
-            let mut v = vec![];
-            let _ = reader.read_to_end(&mut v);
-            v
-        })
-    });
+        // 引数の展開
+        let args = args.iter().flat_map(Value::to_args).collect::<Vec<_>>();
+
+        let external_handle = std::process::Command::new(command)
+            .envs(envs)
+            .args(args)
+            .stdin(stdin)
+            .stdout(stdout)
+            .stderr(stderr)
+            .spawn()
+            .map_err(Error::CommandError)?;
+        command_handles.push(external_handle);
+    }
 
     // 全実行を待つ
-    for handle in command_handles {
-        env.last_status = handle.wait()?;
-    }
-
-    // アウトプットを追記
-    if let Some(output_handle) = output_handle
-        && let Output::Capture(v) = output
-    {
-        let output = output_handle.join().unwrap();
-        v.extend_from_slice(&output);
+    for mut handle in command_handles {
+        env.last_status =
+            status_into_i32(handle.wait().map_err(Error::CommandError)?);
     }
 
     Ok(())
 }
 
-#[derive(Debug)]
-enum ExecutableCommand {
-    Builtin(crate::builtin::BuiltinCommand),
-    External(PathBuf),
+#[cfg(not(unix))]
+pub fn status_into_i32(status: std::process::ExitStatus) -> i32 {
+    status.code().unwrap_or(1)
 }
+#[cfg(unix)]
+pub fn status_into_i32(status: std::process::ExitStatus) -> i32 {
+    status.code().unwrap_or_else(|| {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal().map(|sig| 128 + sig).unwrap_or(1)
+    })
+}
+
 #[derive(Debug)]
 struct ResolvedCommand {
-    command: ExecutableCommand,
+    name: PathBuf,
     envs: Vec<(String, String)>,
     args: Vec<Value>,
     stdin: StdioInputConfig,
@@ -274,6 +217,10 @@ impl ResolvedCommand {
         if name.is_empty() {
             return Err(Error::EmptyCommand);
         }
+        let Some(name) = find_executable(&name)
+        else {
+            return Err(Error::NotFoundCommand(name));
+        };
 
         // 一時環境変数の評価
         let envs: Vec<_> = command
@@ -298,20 +245,8 @@ impl ResolvedCommand {
             .map(|arg| eval_command_part(arg, env))
             .collect::<Result<Vec<_>>>()?;
 
-        // ビルトインコマンドの確認
-        let command = if let Some(command) = find_command(&name) {
-            ExecutableCommand::Builtin(command)
-        }
-        // 外部コマンドの確認
-        else {
-            ExecutableCommand::External(
-                find_executable(&name)
-                    .ok_or(Error::NotFoundCommand(name.to_string()))?,
-            )
-        };
-
         Ok(Self {
-            command,
+            name,
             envs,
             args,
             stdin: StdioInputConfig::default(),
@@ -329,15 +264,6 @@ enum StdioInputConfig {
     PipeReader(std::io::PipeReader),
 }
 impl StdioInputConfig {
-    fn into_read(self) -> Box<dyn std::io::Read> {
-        use StdioInputConfig::*;
-        match self {
-            Inherit => Box::new(std::io::stdin()),
-            String(s) => Box::new(std::io::Cursor::new(s)),
-            File(file) => Box::new(file),
-            PipeReader(pipe) => Box::new(pipe),
-        }
-    }
     fn into_stdio(
         self,
     ) -> Result<(Stdio, Option<JoinHandle<std::io::Result<()>>>)> {
@@ -374,22 +300,6 @@ impl StdioOutputConfig {
             }
         })
     }
-    fn into_write_stdout(self) -> Box<dyn std::io::Write> {
-        use StdioOutputConfig::*;
-        match self {
-            Inherit => Box::new(std::io::stdout()),
-            File(file) => Box::new(file),
-            PipeWriter(pipe) => Box::new(pipe),
-        }
-    }
-    fn into_write_stderr(self) -> Box<dyn std::io::Write> {
-        use StdioOutputConfig::*;
-        match self {
-            Inherit => Box::new(std::io::stderr()),
-            File(file) => Box::new(file),
-            PipeWriter(pipe) => Box::new(pipe),
-        }
-    }
     fn into_stdio(self) -> Stdio {
         use StdioOutputConfig::*;
         match self {
@@ -402,7 +312,6 @@ impl StdioOutputConfig {
 
 fn resolve_pipeline(
     pipeline: &Spanned<Pipeline>,
-    capture: Option<std::io::PipeWriter>,
     env: &mut Context,
 ) -> Result<Vec<ResolvedCommand>> {
     let Pipeline { first, rest } = &pipeline.inner;
@@ -431,12 +340,6 @@ fn resolve_pipeline(
         right.stdin = reader;
 
         commands_with_redirects.push((right, command.inner.redirects.clone()));
-    }
-
-    // キャプチャー設定
-    if let Some(capture) = capture {
-        commands_with_redirects.last_mut().unwrap().0.stdout =
-            StdioOutputConfig::PipeWriter(capture);
     }
 
     // リダイレクトの反映
@@ -649,6 +552,17 @@ fn get_pathext() -> Vec<OsString> {
 fn get_path() -> Vec<PathBuf> {
     // var_osを使用するとより正確
     std::env::var("PATH")
-        .map(|paths| std::env::split_paths(&paths).collect())
+        .map(|paths| {
+            use std::sync::LazyLock;
+            static BUILTIN_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
+                std::env::current_exe()
+                    .expect("自身のファイルパスの取得に失敗しました")
+            });
+            // 最初にビルトインコマンドを探す
+            [BUILTIN_DIR.clone()]
+                .into_iter()
+                .chain(std::env::split_paths(&paths))
+                .collect()
+        })
         .unwrap_or_default()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,9 +27,8 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn run_subst_mode<P: AsRef<Path>>(payload_path: P) -> anyhow::Result<()> {
-    let mut payload = payload::read_payload(payload_path)?;
+    let mut payload = payload::read_payload(&payload_path)?;
     exec::execute_command_line(&payload.command, &mut payload.context)?;
-
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,39 @@
-mod builtin;
 mod check;
+mod cli;
 mod eval;
 mod exec;
 mod parse;
+mod payload;
+mod shell_command;
 mod value;
 
+use cli::*;
+
+use std::path::Path;
+
+use clap::Parser;
+
 fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Some(Commands::Subst { payload_path }) => {
+            run_subst_mode(payload_path)?;
+        }
+        None => {
+            run_shell_mode()?;
+        }
+    }
+    Ok(())
+}
+
+fn run_subst_mode<P: AsRef<Path>>(payload_path: P) -> anyhow::Result<()> {
+    let mut payload = payload::read_payload(payload_path)?;
+    exec::execute_command_line(&payload.command, &mut payload.context)?;
+
+    Ok(())
+}
+
+fn run_shell_mode() -> anyhow::Result<()> {
     welcome();
 
     let mut shell = exec::Shell::new();
@@ -31,7 +59,7 @@ fn main() -> anyhow::Result<()> {
 
                 // 検証
                 let mut errors = vec![];
-                check::check_shell_command(&command, &mut errors);
+                check::check_command_line(&command, &mut errors);
                 if !errors.is_empty() {
                     for error in errors {
                         eprintln!("{error:?}");
@@ -52,11 +80,9 @@ fn main() -> anyhow::Result<()> {
         }
     }
 }
-
 fn welcome() {
     println!("Welcome to Asari!");
 }
-
 fn continuation(current_dir: &std::path::Path) {
     use std::io::Write;
     print!("{}>", format_path(current_dir));
@@ -64,7 +90,6 @@ fn continuation(current_dir: &std::path::Path) {
         .flush()
         .expect("stdoutのフラッシュに失敗しました");
 }
-
 fn format_path(path: &std::path::Path) -> String {
     if let Some(home) = dirs::home_dir()
         && let Ok(relative) = path.strip_prefix(&home)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -63,8 +63,18 @@ impl<T: std::fmt::Display> std::fmt::Display for Spanned<T> {
 
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct ShellCommand {
-    pub pipelines: Vec<Spanned<Pipeline>>,
+    pub statements: Vec<Spanned<Statement>>,
     pub comment: Option<Spanned<String>>,
+}
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub enum Statement {
+    Pipeline(Spanned<Pipeline>),
+    EnvAssign(Spanned<EnvAssign>),
+}
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct EnvAssign {
+    pub name: Spanned<String>,
+    pub value: Spanned<CommandPart>,
 }
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct Pipeline {
@@ -78,6 +88,7 @@ pub enum Pipe {
 }
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct Command {
+    pub temp_env: Vec<Spanned<(Spanned<String>, Spanned<CommandPart>)>>,
     pub name: Spanned<CommandPart>,
     pub args: Vec<Spanned<CommandPart>>,
     pub redirects: Vec<Spanned<Redirect>>,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -19,7 +19,7 @@ use winnow::{
     LocatingSlice,
     combinator::{
         alt, delimited, dispatch, empty, fail, not, opt, peek, preceded,
-        repeat, separated, terminated, trace,
+        repeat, separated, trace,
     },
     prelude::*,
     token::{any, rest, take, take_till, take_until, take_while},
@@ -65,6 +65,7 @@ impl<T: std::fmt::Display> std::fmt::Display for Spanned<T> {
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct CommandLine {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub statements: Vec<Spanned<Statement>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub comment: Option<Spanned<String>>,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,21 +5,21 @@ pub mod literal;
 pub mod simple_expr;
 pub mod tools;
 
+use crate::shell_command::ShellCommandKind;
 use crate::value::Type;
-use command::shell_command;
+use command::command_line;
 use error::*;
 use expr::expr;
 use literal::*;
 use simple_expr::simple_expr;
 use tools::*;
 
-#[allow(unused_imports)]
-use winnow::combinator::todo as todo_parser;
+use serde::{Deserialize, Serialize};
 use winnow::{
     LocatingSlice,
     combinator::{
         alt, delimited, dispatch, empty, fail, not, opt, peek, preceded,
-        repeat, separated, trace,
+        repeat, separated, terminated, trace,
     },
     prelude::*,
     token::{any, rest, take, take_till, take_until, take_while},
@@ -32,9 +32,11 @@ fn mix_span(a: &Span, b: &Span) -> Span {
     a.start.min(b.start)..a.end.max(b.end)
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Spanned<T> {
     pub inner: T,
+    #[serde(skip)]
     pub span: Span,
 }
 impl<T> Spanned<T> {
@@ -45,14 +47,14 @@ impl<T> Spanned<T> {
         }
     }
 }
+impl<T: PartialEq> PartialEq for Spanned<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.eq(&other.inner)
+    }
+}
 impl<T: PartialOrd> PartialOrd for Spanned<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.inner.partial_cmp(&other.inner)
-    }
-}
-impl<T: std::fmt::Debug> std::fmt::Debug for Spanned<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.inner.fmt(f)
     }
 }
 impl<T: std::fmt::Display> std::fmt::Display for Spanned<T> {
@@ -61,73 +63,85 @@ impl<T: std::fmt::Display> std::fmt::Display for Spanned<T> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
-pub struct ShellCommand {
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct CommandLine {
     pub statements: Vec<Spanned<Statement>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub comment: Option<Spanned<String>>,
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Statement {
+    ShellCommand(Spanned<ShellCommand>),
     Pipeline(Spanned<Pipeline>),
     EnvAssign(Spanned<EnvAssign>),
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct ShellCommand {
+    pub kind: Spanned<ShellCommandKind>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<Spanned<CommandPart>>,
+}
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct EnvAssign {
     pub name: Spanned<String>,
     pub value: Spanned<Expr>,
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Pipeline {
     pub first: Spanned<Command>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rest: Vec<(Spanned<Pipe>, Spanned<Command>)>,
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Pipe {
     Stdout,       // |   stdoutのみ
     StdoutStderr, // |&  stdout + stderr
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Command {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub temp_env: Vec<Spanned<(Spanned<String>, Spanned<Expr>)>>,
     pub name: Spanned<CommandPart>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<Spanned<CommandPart>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub redirects: Vec<Spanned<Redirect>>,
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Redirect {
     Input(InputRedirect),
     Output(((OutputRedirect, OutputMode), Spanned<CommandPart>)),
     Merge(MergeRedirect),
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum InputRedirect {
     File(Spanned<CommandPart>),       // <    file
     HereDoc(Spanned<String>),         // <<   EOF ... EOF
     HereString(Spanned<CommandPart>), // <<< "string"
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum OutputRedirect {
     Stdout, // >  >>
     Stderr, // 2> 2>>
     Both,   // &> &>>
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum OutputMode {
     Truncate, // >  2>  &>
     Append,   // >> 2>> &>>
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum MergeRedirect {
     StderrToStdout, // 2>&1
     StdoutToStderr, // 1>&2
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum CommandPart {
     Unquoted(Spanned<String>),
     SimpleExpr(Spanned<Expr>),
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum ExprPrefix {
     Not, // !
     Neg, // -
@@ -150,7 +164,7 @@ impl Spanned<ExprPrefix> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum ExprInfix {
     UnwrapOr,     // ^
     Add,          // +
@@ -206,7 +220,7 @@ impl Spanned<ExprInfix> {
     }
 }
 type ExprNode = Box<Spanned<Expr>>;
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum ExprPostfix {
     Unwrap,              // !
     IsSome,              // ?
@@ -235,30 +249,30 @@ impl Spanned<ExprPostfix> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Expr {
     Primary(Spanned<Primary>),
     Prefix(ExprNode, ExprPrefix),
     Infix(ExprNode, ExprNode, ExprInfix),
     Postfix(ExprNode, ExprPostfix),
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Primary {
-    String(String),                           // "abc", 'abc', r"abc"
-    PathString(String),                       // p"abc"
-    SpecialVar(SpecialVar),                   // $?, $$, $!, $@
-    EnvVar(String),                           // $abc
-    ShellVar(String),                         // @abc
-    Paren(Box<Spanned<Expr>>),                // (expr)
-    CommandSubst(Box<Spanned<ShellCommand>>), // $(command args...)
-    Array(Vec<Spanned<Expr>>),                // [e1, e2, ... , ek]
-    Bool(bool),                               // true, false
-    Int(i64),                                 // 123
-    Float(f64),                               // 12.3
-    Option(Option<Box<Spanned<Expr>>>),       // none, some(expr)
-    Unit,                                     // ()
+    String(String),                          // "abc", 'abc', r"abc"
+    PathString(String),                      // p"abc"
+    SpecialVar(SpecialVar),                  // $?, $$, $!, $@
+    EnvVar(String),                          // $abc
+    ShellVar(String),                        // @abc
+    Paren(Box<Spanned<Expr>>),               // (expr)
+    CommandSubst(Box<Spanned<CommandLine>>), // $(command args...)
+    Array(Vec<Spanned<Expr>>),               // [e1, e2, ... , ek]
+    Bool(bool),                              // true, false
+    Int(i64),                                // 123
+    Float(f64),                              // 12.3
+    Option(Option<Box<Spanned<Expr>>>),      // none, some(expr)
+    Unit,                                    // ()
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum SpecialVar {
     ExitStatus,    // $?
     Pid,           // $$
@@ -272,59 +286,67 @@ type SpannedResult<O> = ModalResult<Spanned<O>>;
 pub fn parse_shell_command(
     input: &str,
 ) -> Result<
-    Spanned<ShellCommand>,
+    Spanned<CommandLine>,
     winnow::error::ParseError<LocatingSlice<&str>, ParseError>,
 > {
-    delimited(space0, shell_command, space0).parse(Input::new(input))
+    delimited(space0, command_line, space0).parse(Input::new(input))
 }
 
 fn space0<'a>(input: &mut Input<'a>) -> ModalResult<&'a str> {
-    take_while(0.., char::is_whitespace).parse_next(input)
+    trace("space0", take_while(0.., char::is_whitespace)).parse_next(input)
 }
 fn space1<'a>(input: &mut Input<'a>) -> ModalResult<&'a str> {
-    take_while(1.., char::is_whitespace).parse_next(input)
+    trace("space1", take_while(1.., char::is_whitespace)).parse_next(input)
 }
 fn ident(input: &mut Input) -> ModalResult<String> {
     use unicode_ident::*;
-    (
-        any.map_err_with_span(|()| ParseErrorKind::NoIdent)
-            .try_map_with_span(|c| {
-                if c == '_' || is_xid_start(c) {
-                    Ok(c)
-                }
-                else {
-                    Err(ParseErrorKind::NoIdent)
-                }
-            }),
-        take_while(0.., is_xid_continue),
+    trace(
+        "ident",
+        (
+            any.map_err_with_span(|()| ParseErrorKind::NoIdent)
+                .try_map_with_span(|c| {
+                    if c == '_' || is_xid_start(c) {
+                        Ok(c)
+                    }
+                    else {
+                        Err(ParseErrorKind::NoIdent)
+                    }
+                }),
+            take_while(0.., is_xid_continue),
+        ),
     )
-        .try_map_with_span(|(ident_start, ident_continue)| {
-            if ident_start == '_' && ident_continue.is_empty() {
-                Err(ParseErrorKind::InvalidIdent)
-            }
-            else {
-                Ok(String::from(ident_start) + ident_continue)
-            }
-        })
-        .cut()
-        .parse_next(input)
+    .try_map_with_span(|(ident_start, ident_continue)| {
+        if ident_start == '_' && ident_continue.is_empty() {
+            Err(ParseErrorKind::InvalidIdent)
+        }
+        else {
+            Ok(String::from(ident_start) + ident_continue)
+        }
+    })
+    .parse_next(input)
 }
 fn keyword<'a>(
     s: &'static str,
 ) -> impl Parser<Input<'a>, &'a str, winnow::error::ErrMode<ParseError>> {
-    (
-        s,
-        peek(not(any.verify(|c| unicode_ident::is_xid_continue(*c)))),
+    trace(
+        "keyword",
+        (
+            s,
+            peek(not(any.verify(|c| unicode_ident::is_xid_continue(*c)))),
+        ),
     )
-        .map(|(s, _)| s)
+    .map(|(s, _)| s)
 }
 fn special_var(input: &mut Input) -> ModalResult<SpecialVar> {
-    dispatch!(any;
-        '?' => empty.value(SpecialVar::ExitStatus),
-        '$' => empty.value(SpecialVar::Pid),
-        '!' => empty.value(SpecialVar::BackgroundPid),
-        '@' => empty.value(SpecialVar::ShellName),
-        _ => fail,
+    trace(
+        "special_var",
+        dispatch! {any;
+            '?' => empty.value(SpecialVar::ExitStatus),
+            '$' => empty.value(SpecialVar::Pid),
+            '!' => empty.value(SpecialVar::BackgroundPid),
+            '@' => empty.value(SpecialVar::ShellName),
+            _ => fail,
+        },
     )
     .parse_next(input)
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -74,7 +74,7 @@ pub enum Statement {
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct EnvAssign {
     pub name: Spanned<String>,
-    pub value: Spanned<CommandPart>,
+    pub value: Spanned<Expr>,
 }
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct Pipeline {
@@ -88,7 +88,7 @@ pub enum Pipe {
 }
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct Command {
-    pub temp_env: Vec<Spanned<(Spanned<String>, Spanned<CommandPart>)>>,
+    pub temp_env: Vec<Spanned<(Spanned<String>, Spanned<Expr>)>>,
     pub name: Spanned<CommandPart>,
     pub args: Vec<Spanned<CommandPart>>,
     pub redirects: Vec<Spanned<Redirect>>,

--- a/src/parse/command.rs
+++ b/src/parse/command.rs
@@ -2,17 +2,40 @@ use super::*;
 
 pub fn shell_command(input: &mut Input) -> SpannedResult<ShellCommand> {
     (
-        separated(0.., pipeline, (space0, ';', space0)),
+        separated(0.., statement, (space0, ';', space0)),
         opt((space0, ';')),
         opt(preceded(space0, comment)),
     )
-        .map(|(pipelines, _, comment)| ShellCommand { pipelines, comment })
+        .map(|(statements, _, comment)| ShellCommand {
+            statements,
+            comment,
+        })
         .spanned()
         .parse_next(input)
 }
 pub fn comment(input: &mut Input) -> SpannedResult<String> {
     preceded('#', rest)
         .map(str::to_string)
+        .spanned()
+        .parse_next(input)
+}
+pub fn statement(input: &mut Input) -> SpannedResult<Statement> {
+    alt((
+        env_assign.map(Statement::EnvAssign),
+        pipeline.map(Statement::Pipeline),
+    ))
+    .spanned()
+    .parse_next(input)
+}
+pub fn env_assign(input: &mut Input) -> SpannedResult<EnvAssign> {
+    (
+        preceded('$', ident).spanned(),
+        space1,
+        "=",
+        space1,
+        command_part,
+    )
+        .map(|(name, _, _, _, value)| EnvAssign { name, value })
         .spanned()
         .parse_next(input)
 }
@@ -37,16 +60,20 @@ pub fn command(input: &mut Input) -> SpannedResult<Command> {
         Redirect(Spanned<Redirect>),
     }
     (
+        repeat(0.., temp_env),
         command_part,
         repeat(
             0..,
-            alt((
-                preceded(space0, redirect).map(ArgOrRedirect::Redirect),
-                preceded(space1, command_part).map(ArgOrRedirect::Arg),
-            )),
+            preceded(
+                space1,
+                alt((
+                    redirect.map(ArgOrRedirect::Redirect),
+                    command_part.map(ArgOrRedirect::Arg),
+                )),
+            ),
         ),
     )
-        .map(|(name, arg_or_redirect): (_, Vec<_>)| {
+        .map(|(temp_env, name, arg_or_redirect): (Vec<_>, _, Vec<_>)| {
             let mut args = vec![];
             let mut redirects = vec![];
             for arg_or_redirect in arg_or_redirect {
@@ -58,11 +85,26 @@ pub fn command(input: &mut Input) -> SpannedResult<Command> {
                 }
             }
             Command {
+                temp_env,
                 name,
                 args,
                 redirects,
             }
         })
+        .spanned()
+        .parse_next(input)
+}
+pub fn temp_env(
+    input: &mut Input,
+) -> SpannedResult<(Spanned<String>, Spanned<CommandPart>)> {
+    (
+        preceded('$', ident).spanned(),
+        space1,
+        ":=",
+        space1,
+        command_part,
+    )
+        .map(|(var, _, _, _, val)| (var, val))
         .spanned()
         .parse_next(input)
 }

--- a/src/parse/command.rs
+++ b/src/parse/command.rs
@@ -1,17 +1,20 @@
 use super::*;
 
-pub fn shell_command(input: &mut Input) -> SpannedResult<ShellCommand> {
-    (
-        separated(0.., statement, (space0, ';', space0)),
-        opt((space0, ';')),
-        opt(preceded(space0, comment)),
+pub fn command_line(input: &mut Input) -> SpannedResult<CommandLine> {
+    trace(
+        "command_line",
+        (
+            separated(0.., statement, (space0, ';', space0)),
+            opt((space0, ';')),
+            opt(preceded(space0, comment)),
+        ),
     )
-        .map(|(statements, _, comment)| ShellCommand {
-            statements,
-            comment,
-        })
-        .spanned()
-        .parse_next(input)
+    .map(|(statements, _, comment)| CommandLine {
+        statements,
+        comment,
+    })
+    .spanned()
+    .parse_next(input)
 }
 pub fn comment(input: &mut Input) -> SpannedResult<String> {
     preceded('#', rest)
@@ -20,109 +23,166 @@ pub fn comment(input: &mut Input) -> SpannedResult<String> {
         .parse_next(input)
 }
 pub fn statement(input: &mut Input) -> SpannedResult<Statement> {
-    alt((
-        env_assign.map(Statement::EnvAssign),
-        pipeline.map(Statement::Pipeline),
-    ))
+    use Statement::*;
+    trace(
+        "statement",
+        alt((
+            shell_command.map(ShellCommand),
+            env_assign.map(EnvAssign),
+            pipeline.map(Pipeline),
+        )),
+    )
     .spanned()
     .parse_next(input)
 }
-pub fn env_assign(input: &mut Input) -> SpannedResult<EnvAssign> {
-    (preceded('$', ident).spanned(), space1, "=", space1, expr)
-        .map(|(name, _, _, _, value)| EnvAssign { name, value })
+pub fn shell_command(input: &mut Input) -> SpannedResult<ShellCommand> {
+    trace(
+        "shell_command",
+        (
+            shell_command_kind,
+            repeat(0.., preceded(space1, command_part)),
+        ),
+    )
+    .map(|(kind, args)| ShellCommand { kind, args })
+    .spanned()
+    .parse_next(input)
+}
+pub fn shell_command_kind(
+    input: &mut Input,
+) -> SpannedResult<ShellCommandKind> {
+    unquoted_string
+        .verify_map(|name| crate::shell_command::find_shell_command(&name))
         .spanned()
         .parse_next(input)
 }
-pub fn pipeline(input: &mut Input) -> SpannedResult<Pipeline> {
-    (
-        command,
-        repeat(0.., (delimited(space0, pipe, space0), command)),
+pub fn env_assign(input: &mut Input) -> SpannedResult<EnvAssign> {
+    trace(
+        "env_assign",
+        (preceded('$', ident).spanned(), space1, "=", space1, expr),
     )
-        .map(|(first, rest)| Pipeline { first, rest })
-        .spanned()
-        .parse_next(input)
+    .map(|(name, _, _, _, value)| EnvAssign { name, value })
+    .spanned()
+    .parse_next(input)
+}
+pub fn pipeline(input: &mut Input) -> SpannedResult<Pipeline> {
+    trace(
+        "pipeline",
+        (
+            command,
+            repeat(0.., (delimited(space0, pipe, space0), command)),
+        ),
+    )
+    .map(|(first, rest)| Pipeline { first, rest })
+    .spanned()
+    .parse_next(input)
 }
 pub fn pipe(input: &mut Input) -> SpannedResult<Pipe> {
     use Pipe::*;
-    alt(("|&".value(StdoutStderr), "|".value(Stdout)))
+    trace("pipe", alt(("|&".value(StdoutStderr), "|".value(Stdout))))
         .spanned()
         .parse_next(input)
 }
 pub fn command(input: &mut Input) -> SpannedResult<Command> {
-    enum ArgOrRedirect {
-        Arg(Spanned<CommandPart>),
-        Redirect(Spanned<Redirect>),
-    }
-    (
-        repeat(0.., temp_env),
-        command_part,
-        repeat(
-            0..,
-            preceded(
-                space1,
-                alt((
-                    redirect.map(ArgOrRedirect::Redirect),
-                    command_part.map(ArgOrRedirect::Arg),
-                )),
+    trace(
+        "command",
+        alt((
+            // 一時変数付きコマンド
+            // コマンドが無ければcut
+            (
+                separated(1.., temp_env, space1),
+                preceded(space1, command_part).cut(),
+                args_and_redirects,
             ),
-        ),
+            // 通常のコマンド
+            (empty.value(vec![]), command_part, args_and_redirects),
+        )),
     )
-        .map(|(temp_env, name, arg_or_redirect): (Vec<_>, _, Vec<_>)| {
-            let mut args = vec![];
-            let mut redirects = vec![];
-            for arg_or_redirect in arg_or_redirect {
-                match arg_or_redirect {
-                    ArgOrRedirect::Arg(arg) => args.push(arg),
-                    ArgOrRedirect::Redirect(redirect) => {
-                        redirects.push(redirect)
-                    }
-                }
-            }
-            Command {
-                temp_env,
-                name,
-                args,
-                redirects,
-            }
-        })
-        .spanned()
-        .parse_next(input)
+    .map(|(temp_env, name, (args, redirects))| Command {
+        temp_env,
+        name,
+        args,
+        redirects,
+    })
+    .spanned()
+    .parse_next(input)
 }
 pub fn temp_env(
     input: &mut Input,
 ) -> SpannedResult<(Spanned<String>, Spanned<Expr>)> {
-    (preceded('$', ident).spanned(), space1, ":=", space1, expr)
-        .map(|(var, _, _, _, val)| (var, val))
-        .spanned()
-        .parse_next(input)
+    trace(
+        "temp_env",
+        (preceded('$', ident).spanned(), space1, ":=", space1, expr),
+    )
+    .map(|(var, _, _, _, val)| (var, val))
+    .spanned()
+    .parse_next(input)
+}
+fn args_and_redirects(
+    input: &mut Input,
+) -> ModalResult<(Vec<Spanned<CommandPart>>, Vec<Spanned<Redirect>>)> {
+    enum ArgOrRedirect {
+        Arg(Spanned<CommandPart>),
+        Redirect(Spanned<Redirect>),
+    }
+    repeat(
+        0..,
+        preceded(
+            space1,
+            alt((
+                redirect.map(ArgOrRedirect::Redirect),
+                command_part.map(ArgOrRedirect::Arg),
+            )),
+        ),
+    )
+    .map(|items: Vec<ArgOrRedirect>| {
+        let mut args = vec![];
+        let mut redirects = vec![];
+        for item in items {
+            match item {
+                ArgOrRedirect::Arg(a) => args.push(a),
+                ArgOrRedirect::Redirect(r) => redirects.push(r),
+            }
+        }
+        (args, redirects)
+    })
+    .parse_next(input)
 }
 pub fn command_part(input: &mut Input) -> SpannedResult<CommandPart> {
     use CommandPart::*;
-    alt((
-        simple_expr.map(SimpleExpr),
-        unquoted_string.spanned().map(Unquoted),
-    ))
+    trace(
+        "command_part",
+        alt((
+            simple_expr.map(SimpleExpr),
+            unquoted_string.spanned().map(Unquoted),
+        )),
+    )
     .spanned()
     .parse_next(input)
 }
 pub fn redirect(input: &mut Input) -> SpannedResult<Redirect> {
     use Redirect::*;
-    alt((
-        input_redirect.map(Input),
-        merge_redirect.map(Merge),
-        (output_redirect, preceded(space0, command_part)).map(Output),
-    ))
+    trace(
+        "redirect",
+        alt((
+            input_redirect.map(Input),
+            merge_redirect.map(Merge),
+            (output_redirect, preceded(space0, command_part)).map(Output),
+        )),
+    )
     .spanned()
     .parse_next(input)
 }
 pub fn input_redirect(input: &mut Input) -> ModalResult<InputRedirect> {
     use InputRedirect::*;
-    alt((
-        preceded(("<<<", space0), command_part).map(HereString),
-        //HereDocは後回し
-        //preceded("<<", rest.spanned()).map(|doc| HereDoc(doc.map(str::to_string))),
-        preceded(("<", space0), command_part).map(File),
-    ))
+    trace(
+        "input_redirect",
+        alt((
+            preceded(("<<<", space0), command_part).map(HereString),
+            //HereDocは後回し
+            //preceded("<<", rest.spanned()).map(|doc| HereDoc(doc.map(str::to_string))),
+            preceded(("<", space0), command_part).map(File),
+        )),
+    )
     .parse_next(input)
 }
 pub fn output_redirect(
@@ -130,18 +190,24 @@ pub fn output_redirect(
 ) -> ModalResult<(OutputRedirect, OutputMode)> {
     use OutputMode::*;
     use OutputRedirect::*;
-    alt((
-        "&>>".value((Both, Append)),
-        "&>".value((Both, Truncate)),
-        "2>>".value((Stderr, Append)),
-        "2>".value((Stderr, Truncate)),
-        ">>".value((Stdout, Append)),
-        ">".value((Stdout, Truncate)),
-    ))
+    trace(
+        "output_redirect",
+        alt((
+            "&>>".value((Both, Append)),
+            "&>".value((Both, Truncate)),
+            "2>>".value((Stderr, Append)),
+            "2>".value((Stderr, Truncate)),
+            ">>".value((Stdout, Append)),
+            ">".value((Stdout, Truncate)),
+        )),
+    )
     .parse_next(input)
 }
 pub fn merge_redirect(input: &mut Input) -> ModalResult<MergeRedirect> {
     use MergeRedirect::*;
-    alt(("2>&1".value(StderrToStdout), "1>&2".value(StdoutToStderr)))
-        .parse_next(input)
+    trace(
+        "merge_redirect",
+        alt(("2>&1".value(StderrToStdout), "1>&2".value(StdoutToStderr))),
+    )
+    .parse_next(input)
 }

--- a/src/parse/command.rs
+++ b/src/parse/command.rs
@@ -28,13 +28,7 @@ pub fn statement(input: &mut Input) -> SpannedResult<Statement> {
     .parse_next(input)
 }
 pub fn env_assign(input: &mut Input) -> SpannedResult<EnvAssign> {
-    (
-        preceded('$', ident).spanned(),
-        space1,
-        "=",
-        space1,
-        command_part,
-    )
+    (preceded('$', ident).spanned(), space1, "=", space1, expr)
         .map(|(name, _, _, _, value)| EnvAssign { name, value })
         .spanned()
         .parse_next(input)
@@ -96,14 +90,8 @@ pub fn command(input: &mut Input) -> SpannedResult<Command> {
 }
 pub fn temp_env(
     input: &mut Input,
-) -> SpannedResult<(Spanned<String>, Spanned<CommandPart>)> {
-    (
-        preceded('$', ident).spanned(),
-        space1,
-        ":=",
-        space1,
-        command_part,
-    )
+) -> SpannedResult<(Spanned<String>, Spanned<Expr>)> {
+    (preceded('$', ident).spanned(), space1, ":=", space1, expr)
         .map(|(var, _, _, _, val)| (var, val))
         .spanned()
         .parse_next(input)

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -1,11 +1,11 @@
+use super::Input;
+
 use std::fmt::Display;
 
 use winnow::{
     error::{FromExternalError, ParserError},
     stream::Location,
 };
-
-use super::Input;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum ParseErrorKind {

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use winnow::{ascii::digit1, stream::Offset};
+
 pub fn bin_int(input: &mut Input) -> ModalResult<i64> {
     trace(
         "bin_int",
@@ -65,114 +66,136 @@ pub fn dec_number(input: &mut Input) -> ModalResult<Primary> {
     }
 }
 pub fn number(input: &mut Input) -> ModalResult<Primary> {
-    dispatch! {peek(opt(take(2_usize)));
-        Some("0b") => preceded("0b", bin_int).map(Primary::Int),
-        Some("0o") => preceded("0o", oct_int).map(Primary::Int),
-        Some("0x") => preceded("0x", hex_int).map(Primary::Int),
-        _ => dec_number,
-    }
+    trace(
+        "number",
+        dispatch! {peek(opt(take(2_usize)));
+            Some("0b") => preceded("0b", bin_int).map(Primary::Int),
+            Some("0o") => preceded("0o", oct_int).map(Primary::Int),
+            Some("0x") => preceded("0x", hex_int).map(Primary::Int),
+            _ => dec_number,
+        },
+    )
     .parse_next(input)
 }
 
 pub fn expr_primary(input: &mut Input) -> SpannedResult<Primary> {
-    dispatch!(peek(any);
-        '\'' => quoted_string.map(Primary::String),
-        '"' => double_quoted_string.map(Primary::String),
-        '$' => preceded('$', alt((
-            delimited(('(', space0), shell_command, (space0, ')'))
-                .map(|shell_command| Primary::CommandSubst(Box::new(shell_command))),
-            special_var.map(Primary::SpecialVar),
-            ident.map(Primary::EnvVar),
-        ))),
-        '@' => preceded('@', ident).map(Primary::ShellVar),
-        '(' => alt((
-            ('(', space0, ')').value(Primary::Unit),
-            delimited(('(', space0), expr, (space0, ')'))
-                .map(|expr| Primary::Paren(Box::new(expr)))
-        )),
-        'r' => raw_string.map(Primary::String),
-        'p' => path_string.map(Primary::PathString),
-        '[' => delimited(('[', space0), separated(0.., expr, delimited(space0, ',', space0)), ']')
-            .map(|exprs| {
-                Primary::Array(exprs)
-            }),
-        't' => keyword("true").value(Primary::Bool(true)),
-        'f' => keyword("false").value(Primary::Bool(false)),
-        '0'..='9' => number,
-        'n' => keyword("none").value(Primary::Option(None)),
-        's' => delimited((keyword("some"), space0, '(', space0), expr, (space0, ')'))
-            .map(|expr| Primary::Option(Some(Box::new(expr)))),
-        _ => fail,
+    trace(
+        "expr_primary",
+        dispatch! {peek(any);
+            '\'' => quoted_string.map(Primary::String),
+            '"' => double_quoted_string.map(Primary::String),
+            '$' => preceded('$', alt((
+                delimited(('(', space0), command_line, (space0, ')'))
+                    .map(|shell_command| Primary::CommandSubst(Box::new(shell_command))),
+                special_var.map(Primary::SpecialVar),
+                ident.cut().map(Primary::EnvVar),
+            ))),
+            '@' => preceded('@', ident).cut().map(Primary::ShellVar),
+            '(' => alt((
+                ('(', space0, ')').value(Primary::Unit),
+                delimited(('(', space0), expr, (space0, ')'))
+                    .map(|expr| Primary::Paren(Box::new(expr)))
+            )),
+            'r' => raw_string.map(Primary::String),
+            'p' => path_string.map(Primary::PathString),
+            '[' => delimited(('[', space0), separated(0.., expr, delimited(space0, ',', space0)), ']')
+                .map(|exprs| {
+                    Primary::Array(exprs)
+                }),
+            't' => keyword("true").value(Primary::Bool(true)),
+            'f' => keyword("false").value(Primary::Bool(false)),
+            '0'..='9' => number,
+            'n' => keyword("none").value(Primary::Option(None)),
+            's' => delimited((keyword("some"), space0, '(', space0), expr, (space0, ')'))
+                .map(|expr| Primary::Option(Some(Box::new(expr)))),
+            _ => fail,
+        },
     )
     .spanned()
     .parse_next(input)
 }
 pub fn expr_prefix(input: &mut Input) -> SpannedResult<ExprPrefix> {
     use ExprPrefix::*;
-    dispatch! {any;
-        '!' => empty.value(Not),
-        '-' => empty.value(Neg),
-        _ => fail,
-    }
+    trace(
+        "expr_prefix",
+        dispatch! {any;
+            '!' => empty.value(Not),
+            '-' => empty.value(Neg),
+            _ => fail,
+        },
+    )
     .spanned()
     .parse_next(input)
 }
 pub fn expr_infix(input: &mut Input) -> SpannedResult<ExprInfix> {
     use ExprInfix::*;
-    dispatch! {any;
-        '^' => empty.value(UnwrapOr),
-        '+' => empty.value(Add),
-        '-' => empty.value(Sub),
-        '*' => empty.value(Mul),
-        '/' => empty.value(Div),
-        '%' => empty.value(Rem),
-        '=' => '='.value(Equal),
-        '!' => '='.value(NotEqual),
-        '<' => opt('='.value(LessEqual))
-                .map(|c| c.unwrap_or(Less)),
-        '>' => opt('='.value(GreaterEqual))
-                .map(|c| c.unwrap_or(Greater)),
-        '&' => '&'.value(And),
-        '|' => '|'.value(Or),
-        _ => fail,
-    }
+    trace(
+        "expr_infix",
+        dispatch! {any;
+            '^' => empty.value(UnwrapOr),
+            '+' => empty.value(Add),
+            '-' => empty.value(Sub),
+            '*' => empty.value(Mul),
+            '/' => empty.value(Div),
+            '%' => empty.value(Rem),
+            '=' => '='.value(Equal),
+            '!' => '='.value(NotEqual),
+            '<' => opt('='.value(LessEqual))
+                    .map(|c| c.unwrap_or(Less)),
+            '>' => opt('='.value(GreaterEqual))
+                    .map(|c| c.unwrap_or(Greater)),
+            '&' => '&'.value(And),
+            '|' => '|'.value(Or),
+            _ => fail,
+        },
+    )
     .spanned()
     .parse_next(input)
 }
 pub fn expr_postfix(input: &mut Input) -> SpannedResult<ExprPostfix> {
     use ExprPostfix::*;
-    dispatch! {any;
-        '!' => empty.value(Unwrap),
-        '?' => empty.value(IsSome),
-        '@' => empty.value(Length),
-        '[' => delimited(space0, expr, (space0, ']'))
-            .map(|index| Index(Box::new(index))),
-        'a' => preceded(('s', space0), expr_type)
-            .map(Cast),
-        _ => fail,
-    }
+    trace(
+        "expr_prefix",
+        dispatch! {any;
+            '!' => empty.value(Unwrap),
+            '?' => empty.value(IsSome),
+            '@' => empty.value(Length),
+            '[' => delimited(space0, expr, (space0, ']'))
+                .map(|index| Index(Box::new(index))),
+            'a' => preceded(('s', space0), expr_type)
+                .map(Cast),
+            _ => fail,
+        },
+    )
     .spanned()
     .parse_next(input)
 }
 pub fn expr_type(input: &mut Input) -> SpannedResult<Type> {
     use Type::*;
     let mut type_name = take_while(1.., 'a'..='z');
-    dispatch! {type_name;
-        "string" => empty.value(String),
-        "int" => empty.value(Int),
-        "float" => empty.value(Float),
-        "bool" => empty.value(Bool),
-        "array" => delimited((space0, '<', space0), expr_type, (space0, '>', space0))
-            .map(|t| Array(Box::new(t.inner))),
-        "option" => delimited((space0, '<', space0), expr_type, (space0, '>', space0))
-            .map(|t| Option(Box::new(t.inner))),
-        "unit" => empty.value(Unit),
-        _ => fail,
-    }
+    trace(
+        "expr_type",
+        dispatch! {type_name;
+            "string" => empty.value(String),
+            "int" => empty.value(Int),
+            "float" => empty.value(Float),
+            "bool" => empty.value(Bool),
+            "array" => delimited((space0, '<', space0), expr_type, (space0, '>', space0))
+                .map(|t| Array(Box::new(t.inner))),
+            "option" => delimited((space0, '<', space0), expr_type, (space0, '>', space0))
+                .map(|t| Option(Box::new(t.inner))),
+            "unit" => empty.value(Unit),
+            _ => fail,
+        },
+    )
     .spanned()
     .parse_next(input)
 }
 pub fn expr(input: &mut Input) -> SpannedResult<Expr> {
+    trace("expr", expr_pratt_top).parse_next(input)
+}
+#[inline(always)]
+fn expr_pratt_top(input: &mut Input) -> SpannedResult<Expr> {
     expr_pratt(input, 0)
 }
 fn expr_pratt(input: &mut Input, min_power: i32) -> SpannedResult<Expr> {
@@ -199,8 +222,8 @@ fn expr_pratt(input: &mut Input, min_power: i32) -> SpannedResult<Expr> {
     };
 
     loop {
-        let _ = space0.parse_next(input)?;
         let checkpoint = input.checkpoint();
+        let _ = space0.parse_next(input)?;
 
         // 中置演算子
         if let Some(infix) = opt(expr_infix).parse_next(input)? {
@@ -226,6 +249,7 @@ fn expr_pratt(input: &mut Input, min_power: i32) -> SpannedResult<Expr> {
             continue;
         }
 
+        input.reset(&checkpoint);
         break;
     }
 

--- a/src/parse/simple_expr.rs
+++ b/src/parse/simple_expr.rs
@@ -2,55 +2,68 @@ use super::*;
 
 // 変数と配列とクォート系と括弧のみのexpr_primary
 pub fn simple_expr_primary(input: &mut Input) -> SpannedResult<Primary> {
-    dispatch!(peek(any);
-        '\'' => quoted_string.map(Primary::String),
-        '"' => double_quoted_string.map(Primary::String),
-        '$' => preceded('$', alt((
-            delimited(('(', space0), shell_command, (space0, ')'))
-                .map(|shell_command| Primary::CommandSubst(Box::new(shell_command))),
-            special_var.map(Primary::SpecialVar),
-            ident.map(Primary::EnvVar),
-        ))),
-        '@' => preceded('@', ident).map(Primary::ShellVar),
-        '(' => alt((
-            ('(', space0, ')').value(Primary::Unit),
-            delimited(('(', space0), expr, (space0, ')'))
-                .map(|expr| Primary::Paren(Box::new(expr)))
-        )),
-        'r' => raw_string.map(Primary::String),
-        'p' => path_string.map(Primary::PathString),
-        '[' => delimited(('[', space0), separated(0.., expr, delimited(space0, ',', space0)), ']')
-            .map(|exprs| {
-                Primary::Array(exprs)
-            }),
-        _ => fail,
+    trace(
+        "simple_expr_primary",
+        dispatch! {peek(any);
+            '\'' => quoted_string.map(Primary::String),
+            '"' => double_quoted_string.map(Primary::String),
+            '$' => preceded('$', alt((
+                delimited(('(', space0), command_line, (space0, ')'))
+                    .map(|shell_command| Primary::CommandSubst(Box::new(shell_command))),
+                special_var.map(Primary::SpecialVar),
+                ident.cut().map(Primary::EnvVar),
+            ))),
+            '@' => preceded('@', ident).cut().map(Primary::ShellVar),
+            '(' => alt((
+                ('(', space0, ')').value(Primary::Unit),
+                delimited(('(', space0), expr, (space0, ')'))
+                    .map(|expr| Primary::Paren(Box::new(expr)))
+            )),
+            'r' => raw_string.map(Primary::String),
+            'p' => path_string.map(Primary::PathString),
+            '[' => delimited(('[', space0), separated(0.., expr, delimited(space0, ',', space0)), ']')
+                .map(|exprs| {
+                    Primary::Array(exprs)
+                }),
+            _ => fail,
+        },
     )
     .spanned()
     .parse_next(input)
 }
 pub fn simple_expr_postfix(input: &mut Input) -> SpannedResult<ExprPostfix> {
     use ExprPostfix::*;
-    dispatch!(any;
-        '!' => empty.value(Unwrap),
-        '?' => empty.value(IsSome),
-        '@' => empty.value(Length),
-        '[' => delimited(space0, expr, (space0, ']'))
-            .map(|index|Index(Box::new(index))),
-        _ => fail,
+    trace(
+        "simple_expr_postfix",
+        dispatch! {any;
+            '!' => empty.value(Unwrap),
+            '?' => empty.value(IsSome),
+            '@' => empty.value(Length),
+            '[' => delimited(space0, expr, (space0, ']'))
+                .map(|index|Index(Box::new(index))),
+            _ => fail,
+        },
     )
     .spanned()
     .parse_next(input)
 }
 pub fn simple_expr_infix(input: &mut Input) -> SpannedResult<ExprInfix> {
     use ExprInfix::*;
-    dispatch!(any;
-        '^' => empty.value(UnwrapOr),
-        _ => fail,
+    trace(
+        "simple_expr_infix",
+        dispatch! {any;
+            '^' => empty.value(UnwrapOr),
+            _ => fail,
+        },
     )
     .spanned()
     .parse_next(input)
 }
+#[inline(always)]
 pub fn simple_expr(input: &mut Input) -> SpannedResult<Expr> {
+    trace("simple_expr", simple_expr_pratt).parse_next(input)
+}
+pub fn simple_expr_pratt(input: &mut Input) -> SpannedResult<Expr> {
     // 値
     let primary = simple_expr_primary.parse_next(input)?;
     let mut lhs = Spanned {

--- a/src/parse/tools.rs
+++ b/src/parse/tools.rs
@@ -1,7 +1,9 @@
 mod impls;
 
 use crate::parse::error::*;
+
 use std::marker::PhantomData;
+
 use winnow::{
     Parser,
     error::{ErrMode, FromExternalError, ModalError, ParserError},

--- a/src/parse/tools/impls.rs
+++ b/src/parse/tools/impls.rs
@@ -1,5 +1,7 @@
 use crate::parse::error::*;
+
 use std::marker::PhantomData;
+
 use winnow::{
     ModalResult, Parser,
     error::{ErrMode, FromExternalError, ModalError, ParserError},

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,0 +1,55 @@
+use crate::eval::Context;
+use crate::parse::{CommandLine, Spanned};
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct SubstPayload {
+    pub command: Spanned<CommandLine>,
+    pub context: Context,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    IoError(std::io::Error),
+    ParseError(serde_json::Error),
+}
+impl std::error::Error for Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+// 一時ファイルへファイルを保存
+pub fn write_payload(payload: &SubstPayload) -> std::io::Result<PathBuf> {
+    let temp_dir = std::env::temp_dir();
+
+    // 適当に被らなさそうな名前を被らなくなるまで作る
+    let path = loop {
+        let name = format!(
+            "asari_subst_{:X}_{:X}.txt",
+            // プロセスID
+            std::process::id(),
+            // 現在時刻（ナノ秒）
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |duration| duration.as_nanos()),
+        );
+        let path = temp_dir.join(name);
+        if !path.exists() {
+            break path;
+        }
+    };
+
+    let json = serde_json::to_vec(payload).unwrap();
+    std::fs::write(&path, json)?;
+    Ok(path)
+}
+
+pub fn read_payload<P: AsRef<Path>>(path: P) -> Result<SubstPayload, Error> {
+    let data = std::fs::read(path).map_err(Error::IoError)?;
+    serde_json::from_slice(&data).map_err(Error::ParseError)
+}

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -23,8 +23,25 @@ impl std::fmt::Display for Error {
     }
 }
 
+pub struct TempFile(PathBuf);
+impl AsRef<std::ffi::OsStr> for TempFile {
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        self.0.as_os_str()
+    }
+}
+impl AsRef<Path> for TempFile {
+    fn as_ref(&self) -> &Path {
+        self.0.as_path()
+    }
+}
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
 // 一時ファイルへファイルを保存
-pub fn write_payload(payload: &SubstPayload) -> std::io::Result<PathBuf> {
+pub fn write_payload(payload: &SubstPayload) -> std::io::Result<TempFile> {
     let temp_dir = std::env::temp_dir();
 
     // 適当に被らなさそうな名前を被らなくなるまで作る
@@ -46,7 +63,7 @@ pub fn write_payload(payload: &SubstPayload) -> std::io::Result<PathBuf> {
 
     let json = serde_json::to_vec(payload).unwrap();
     std::fs::write(&path, json)?;
-    Ok(path)
+    Ok(TempFile(path))
 }
 
 pub fn read_payload<P: AsRef<Path>>(path: P) -> Result<SubstPayload, Error> {

--- a/src/shell_command.rs
+++ b/src/shell_command.rs
@@ -1,7 +1,9 @@
 use crate::value::Value;
 
 use std::fmt::Display;
-use std::io::{Error as IoError, Read, Write};
+use std::io::Error as IoError;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub enum Error {
@@ -22,30 +24,24 @@ impl Display for Error {
 }
 pub type Result<T> = ::std::result::Result<T, Error>;
 
-#[derive(Clone, Copy, Debug)]
-pub enum BuiltinCommand {
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum ShellCommandKind {
     Cd,
     Exit,
 }
-pub fn find_command(name: &str) -> Option<BuiltinCommand> {
-    use BuiltinCommand::*;
+pub fn find_shell_command(name: &str) -> Option<ShellCommandKind> {
+    use ShellCommandKind::*;
     Some(match name {
         "cd" => Cd,
         "exit" => Exit,
         _ => None?,
     })
 }
-pub fn run(
-    command: BuiltinCommand,
-    args: &[Value],
-    stdin: Box<dyn Read>,
-    stdout: Box<dyn Write>,
-    stderr: Box<dyn Write>,
-) -> Result<i32> {
-    use BuiltinCommand::*;
+pub fn run(command: ShellCommandKind, args: &[Value]) -> Result<i32> {
+    use ShellCommandKind::*;
     let result = match command {
-        Cd => cd(args, stdin, stdout, stderr),
-        Exit => exit(args, stdin, stdout, stderr),
+        Cd => cd(args),
+        Exit => exit(args),
     };
     if let Err(Error::Stdio(e)) = &result
         && e.kind() == std::io::ErrorKind::BrokenPipe
@@ -54,12 +50,7 @@ pub fn run(
     }
     result
 }
-fn cd(
-    args: &[Value],
-    _stdin: Box<dyn Read>,
-    _stdout: Box<dyn Write>,
-    _stderr: Box<dyn Write>,
-) -> Result<i32> {
+fn cd(args: &[Value]) -> Result<i32> {
     if 1 < args.len() {
         return Err(Error::InvalidArgs);
     }
@@ -96,14 +87,9 @@ fn cd(
     Ok(0)
 }
 // 終了優先
-fn exit(
-    args: &[Value],
-    _stdin: Box<dyn Read>,
-    _stdout: Box<dyn Write>,
-    mut stderr: Box<dyn Write>,
-) -> Result<i32> {
+fn exit(args: &[Value]) -> Result<i32> {
     if 1 < args.len() {
-        writeln!(stderr, "引数が2つ以上です")?;
+        eprintln!("引数が2つ以上です");
     }
 
     let mut exit_code = 0;
@@ -114,7 +100,7 @@ fn exit(
                     exit_code = code;
                 }
                 else {
-                    writeln!(stderr, "数値が終了コードの範囲外です")?;
+                    eprintln!("数値が終了コードの範囲外です");
                     exit_code = -1;
                 }
             }
@@ -123,15 +109,12 @@ fn exit(
                     exit_code = code;
                 }
                 else {
-                    writeln!(
-                        stderr,
-                        "文字列を終了コードに変換できませんでした"
-                    )?;
+                    eprintln!("文字列を終了コードに変換できませんでした");
                     exit_code = -1;
                 }
             }
             _ => {
-                writeln!(stderr, "引数が整数または文字列ではありません")?;
+                eprintln!("引数が整数または文字列ではありません");
                 exit_code = -1;
             }
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,8 @@
 use super::eval::Error;
 
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Value {
     String(String),
     Int(i64),
@@ -10,7 +12,7 @@ pub enum Value {
     Option(Option<Box<Value>>),
     Unit,
 }
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Type {
     String,
     Int,


### PR DESCRIPTION
環境変数の設定
ビルトインコマンドとシェルコマンドに分離
ビルトインコマンドは、外部コマンドと同じだがシェルに同梱する
シェルコマンドはシェルの状態を変え、パイプやリダイレクトや一時変数が使えない。
コマンド置換を子プロセス化
それに伴いserdeとserde_jsonとclapを依存に追加